### PR TITLE
Added `data-grammar="text md"` to the keybindings selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 It folds and unfolds markdown sections following the headers.
 
-This package is inspired by the package [markdown-foler](https://github.com/tshort/markdown-folder), but unfortunately after Atom 1.9.0 that package [stop working](https://github.com/tshort/markdown-folder/issues/19) and I reimplemented some of its functionality.
+This package is inspired by the package [markdown-folder](https://github.com/tshort/markdown-folder), but unfortunately after Atom 1.9.0 that package [stopped working](https://github.com/tshort/markdown-folder/issues/19) and I reimplemented some of its functionality.
 
 Commands:
 1. 'markdown-folding:cycle': => Cycle heading at cursor (Show headings of subsections - collapse all - show all)
@@ -11,6 +11,6 @@ Commands:
 
 Suggested bindings (not implemented, use in your personal settings if you like):
 ```
-'atom-text-editor[data-grammar="source gfm"]:not([mini])':
-  'tab':        'markdown-folding:cycle'
+'atom-text-editor[data-grammar="source gfm"]:not([mini]), atom-text-editor[data-grammar="text md"]:not([mini])':
+  'tab': 'markdown-folding:cycle'
 ```


### PR DESCRIPTION
It looks like in some cases Atom detects a markdown file as `text md` instead of `source gfm`.

I tried to come up with a shorter CSS selector but couldn't find any - tried a few things from here: https://stackoverflow.com/q/24944800/1668200